### PR TITLE
Allow users to modify summary

### DIFF
--- a/srcref.inc.php
+++ b/srcref.inc.php
@@ -25,7 +25,7 @@ function plugin_srcref_convert()
 	}
 	$html = "";
 	$html .= "<details>\n";
-	$html .= "  <summary>Source : " . plugin_ref_inline(func_get_args()[0]) . "</summary>\n";
+	$html .= "  <summary>" . (func_num_args()===1 ? "Source" : func_get_args()[1]) . " : " . plugin_ref_inline($name) . "</summary>\n";
 	$html .= "  <pre><code>" . htmlspecialchars(file_get_contents($file)) . "</code></pre>\n";
 	$html .= "</details>";
 	return $html;


### PR DESCRIPTION
I want to write some short descriptions for my source codes. So, how about regarding the second arg as a user-defined summary?

Of course, the second arg is optional. Default is still `Source`.

## Example
```
* attach-plugin
#srcref(main.c,Well-known "hello world" in C language);
```
![screenshot from 2018-06-09 02-00-32](https://user-images.githubusercontent.com/20423320/41170816-f352e78a-6b88-11e8-9893-40a695818552.png)

Note: `plugin_ref_inline(func_get_args()[0])` caused error in my local experimental environment. So, I replaced it by `$name`.
